### PR TITLE
Add defattr to %files section of cacophony.spec for passing rpmlint chec...

### DIFF
--- a/contrib/rpm/cacophony.spec
+++ b/contrib/rpm/cacophony.spec
@@ -35,6 +35,7 @@ cp -rf contrib/test-ca-script/* $RPM_BUILD_ROOT/%{_datarootdir}/cacophony/test-c
 
 
 %files
+%defattr(-, root, root)
 %doc README.md LICENSE AUTHORS
 %{python_sitelib}/*
 %{_datarootdir}/cacophony/*


### PR DESCRIPTION
So we can pass rpmlint checks with no Errors
